### PR TITLE
Update tests using cy.session

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,13 @@
 # Histórico de Versões
 
+## [0.7.0] - 07-06-2025
+
+### Adicionado
+
+- Uso do `cy.session` para reutilizar sessões de login.
+- Novo comando customizado `loginWithSession`.
+- Adequação dos testes de homepage e checkout para utilizar a nova sessão.
+
 ## [0.6.1] - 07-06-2025
 
 ### Corrigido

--- a/cypress/e2e/checkout.cy.ts
+++ b/cypress/e2e/checkout.cy.ts
@@ -1,23 +1,19 @@
 describe("Checkout", () => {
   beforeEach(() => {
-    cy.visitSite({ url: "/" });
-  });
-
-  it("Deve ser possível remover um produto do carrinho", () => {
-    cy.loginSuccessfully({
+    cy.loginWithSession({
       email: users.standard_user,
       password: users.password,
     });
+    cy.visit("/inventory.html");
+  });
+
+  it("Deve ser possível remover um produto do carrinho", () => {
     cy.addProductToCart();
     cy.RemoveProductToCart();
     cy.screenshot();
   });
 
   it("Não deve permitir acessar o checkout com o campo username em branco", () => {
-    cy.loginSuccessfully({
-      email: users.standard_user,
-      password: users.password,
-    });
     cy.addProductToCart();
     cy.accessCartPage();
     cy.validateCheckoutError({
@@ -29,10 +25,6 @@ describe("Checkout", () => {
   });
 
   it("Não deve permitir acessar o checkout com o campo lastname em branco", () => {
-    cy.loginSuccessfully({
-      email: users.standard_user,
-      password: users.password,
-    });
     cy.addProductToCart();
     cy.accessCartPage();
     cy.validateCheckoutError({
@@ -44,10 +36,6 @@ describe("Checkout", () => {
   });
 
   it("Não deve permitir acessar o checkout com o campo zipcode em branco", () => {
-    cy.loginSuccessfully({
-      email: users.standard_user,
-      password: users.password,
-    });
     cy.addProductToCart();
     cy.accessCartPage();
     cy.validateCheckoutError({
@@ -59,10 +47,6 @@ describe("Checkout", () => {
   });
 
   it("Deve ser possível finalizar o pedido", () => {
-    cy.loginSuccessfully({
-      email: users.standard_user,
-      password: users.password,
-    });
     cy.addProductToCart();
     cy.accessCartPage();
     cy.fillCheckoutForm({ username: "Test", lastname: "qa", zipcode: "123" });
@@ -71,10 +55,11 @@ describe("Checkout", () => {
   });
 
   it("Campo first name sendo apagado ao preencher campo last name", () => {
-    cy.loginSuccessfully({
+    cy.loginWithSession({
       email: users.problem_user,
       password: users.password,
     });
+    cy.visit("/inventory.html");
     cy.addProductToCart();
     cy.accessCartPage();
     cy.validateWord({ username: "QA", lastname: "test", zipcode: "1234" });

--- a/cypress/e2e/homepage.cy.ts
+++ b/cypress/e2e/homepage.cy.ts
@@ -1,58 +1,38 @@
 describe("Homepage", () => {
   beforeEach(() => {
-    cy.visitSite({ url: "/" });
-  });
-
-  it("Deve exibir imagens diferentes para cada produto", () => {
-    cy.loginSuccessfully({
+    cy.loginWithSession({
       email: users.standard_user,
       password: users.password,
     });
+    cy.visit("/inventory.html");
+  });
+
+  it("Deve exibir imagens diferentes para cada produto", () => {
     cy.validateDifferentImages();
     cy.screenshot();
   });
 
   it("Deve permitir adicionar qualquer produto ao carrinho", () => {
-    cy.loginSuccessfully({
-      email: users.standard_user,
-      password: users.password,
-    });
     cy.addProductToCart();
     cy.screenshot();
   });
 
   it("Deve manter nome, valor e imagem consistentes entre homepage e página de detalhes", () => {
-    cy.loginSuccessfully({
-      email: users.standard_user,
-      password: users.password,
-    });
     cy.compareProductInfo();
     cy.screenshot();
   });
 
   it("Deve ordenar corretamente por nome (Z até A)", () => {
-    cy.loginSuccessfully({
-      email: users.standard_user,
-      password: users.password,
-    });
     cy.sortItems(1);
     cy.screenshot();
   });
 
   it("Deve ordenar corretamente por preço (menor para maior) ", () => {
-    cy.loginSuccessfully({
-      email: users.standard_user,
-      password: users.password,
-    });
     cy.sortItems(2);
     cy.screenshot();
   });
 
   it("Deve ordenar corretamente por preço (maior para Menor)", () => {
-    cy.loginSuccessfully({
-      email: users.standard_user,
-      password: users.password,
-    });
     cy.sortItems(3);
     cy.screenshot();
   });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -37,6 +37,7 @@ declare global {
     interface Chainable {
       doLogin(data?: LoginData): Chainable<void>;
       loginSuccessfully(data: LoginData): Chainable<void>;
+      loginWithSession(data: LoginData): Chainable<void>;
       validateLoginError(data: LoginData): Chainable<void>;
       validateSameImages(): Chainable<void>;
       addProductToCart(): Chainable<void>;

--- a/cypress/support/commands/loginCommands.ts
+++ b/cypress/support/commands/loginCommands.ts
@@ -20,6 +20,13 @@ Cypress.Commands.add("loginSuccessfully", (data: LoginData) => {
   cy.url().should("include", "/inventory.html");
 });
 
+Cypress.Commands.add("loginWithSession", (data: LoginData) => {
+  cy.session([data.email, data.password], () => {
+    cy.visitSite({ url: "/" });
+    cy.loginSuccessfully(data);
+  });
+});
+
 Cypress.Commands.add("validateLoginError", (data: LoginData) => {
   cy.doLogin(data);
   loginPage.getErrorMessage().should("have.text", data.expectedMessage);


### PR DESCRIPTION
## Summary
- reuse login with new `loginWithSession` command
- adopt session login in homepage and checkout specs
- document cy.session usage in project history

## Testing
- `npm run cy:run` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683a4a10e083319914be8080917829